### PR TITLE
Add option for user hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Users module
 
 Users module for MunkiReport. Gathers information about user accounts on the Mac.
 
+Client Preferences
+-----
+It is possible to enable the collection of user account hints on clients using the preference domain MunkiReport with boolean key `user_account_hints_enabled` set to `true`. Alternatively, you can run `sudo defaults write /Library/Preferences/MunkiReport.plist user_account_hints_enabled -bool true` on the client.
 
 
 Table Schema

--- a/scripts/users.py
+++ b/scripts/users.py
@@ -8,6 +8,12 @@ import sys
 from datetime import datetime
 import time
 
+sys.path.insert(0, '/usr/local/munki')
+sys.path.insert(0, '/usr/local/munkireport')
+
+from munkilib import FoundationPlist
+from Foundation import CFPreferencesCopyAppValue
+
 def get_users_info():
 
     # Get all users info as plist
@@ -67,7 +73,7 @@ def process_user_info(all_users,group_names):
                 user_atts['ard_priv'] = user[user_att][0]
             elif user_att == 'dsAttrTypeStandard:AppleMetaNodeLocation':
                 user_atts['node_location'] = user[user_att][0]
-            elif user_att == 'dsAttrTypeStandard:AuthenticationHint':
+            elif user_att == 'dsAttrTypeStandard:AuthenticationHint' and user_account_hints_enabled():
                 user_atts['password_hint'] = user[user_att][0]
             elif user_att == 'dsAttrTypeStandard:GeneratedUID':
                 user_atts['generated_uuid'] = user[user_att][0]
@@ -180,6 +186,9 @@ def process_user_info(all_users,group_names):
 
         out.append(user_atts)
     return out
+
+def user_account_hints_enabled():
+    return CFPreferencesCopyAppValue('user_account_hints_enabled', 'MunkiReport')
 
 def main():
     """Main"""

--- a/views/users_detail_widget.php
+++ b/views/users_detail_widget.php
@@ -3,10 +3,10 @@
     <table id="mr-users-table">
         <tr>
             <th data-i18n="last_user"></th>
-            <td><span class="mr-long_username"></span> (<span class="mr-console_user"></span>)</td>
+            <td><span class="reportdata-long_username"></span> (<span class="reportdata-console_user"></span>)</td>
         </tr>
         <tr>
-            <th data-i18n="user_sessions.last_user_uid"></th><td><span class="mr-uid"></span></td>
+            <th data-i18n="user_sessions.last_user_uid"></th><td><span class="reportdata-uid"></span></td>
         </tr>
     </table>
 </div>


### PR DESCRIPTION
Fix for client widget and rework of client script. 

Contains new client script. 

New client preference for user account hints: 

It is possible to enable the collection of user account hints on clients using the preference domain MunkiReport with boolean key `user_account_hints_enabled` set to `true`. Alternatively, you can run `sudo defaults write /Library/Preferences/MunkiReport.plist user_account_hints_enabled -bool true` on the client.