### PR TITLE
Change search_key back to computer_name

### DIFF
--- a/views/users_local_admins_widget.yml
+++ b/views/users_local_admins_widget.yml
@@ -4,6 +4,6 @@ api_url: /module/users/get_local_admin
 i18n_title: users.local_admins
 icon: fa-user-secret
 listing_link: /show/listing/users/users
-search_key: serial_number
+search_key: computer_name
 i18nEmptyResult: users.no_local_admins
 badge: count


### PR DESCRIPTION
This PR reverses the change by @bochoven from this commit: https://github.com/munkireport/users/commit/a8a5aaf886649fdc695d97aca283c3083dd1e661

I brought this up in Slack a couple times but never got a dialog going. I think the original view is much more useful since it shows the name of the computer in the widget instead of the serial number.

But of course there could definetely be a better reason for this change that I'm just not seeing, but I wanted to open this PR to get a discussion going.