### PR TITLE
Admin and group evaluation

### DIFF
--- a/scripts/users.py
+++ b/scripts/users.py
@@ -46,8 +46,9 @@ def get_group_names():
         for group in groups_pl:
 
             # Process each group record name, some of more than one record name
-            for record_name in group["dsAttrTypeStandard:RecordName"]:
-                group_names.update({record_name: group["dsAttrTypeStandard:RealName"][0].rstrip()})
+            if "dsAttrTypeStandard:RealName" in group:
+                for record_name in group["dsAttrTypeStandard:RecordName"]:
+                    group_names.update({record_name: group["dsAttrTypeStandard:RealName"][0].rstrip()})                   
 
         return group_names
 
@@ -98,7 +99,10 @@ def process_user_info(all_users,group_names):
 
                     # Translate each group to real name
                     for group in output.split(' '):
-                        groups_list.append(group_names[group.rstrip()])
+                        try:
+                            groups_list.append(group_names[group.rstrip()])
+                        except KeyError:
+                            continue
 
                     user_atts['group_memership'] = ", ".join(sorted(groups_list))
 

--- a/scripts/users.py
+++ b/scripts/users.py
@@ -48,7 +48,8 @@ def get_group_names():
             # Process each group record name, some of more than one record name
             if "dsAttrTypeStandard:RealName" in group:
                 for record_name in group["dsAttrTypeStandard:RecordName"]:
-                    group_names.update({record_name: group["dsAttrTypeStandard:RealName"][0].rstrip()})                   
+                    if "Public Folder" not in group["dsAttrTypeStandard:RealName"][0].rstrip():
+                        group_names.update({record_name: group["dsAttrTypeStandard:RealName"][0].rstrip()})                   
 
         return group_names
 


### PR DESCRIPTION
These changes take into account some fringe cases that was causing the group name function to return blank:

1. If the Group being evaluated doesn't have a "RealName" it stops the evaluation of all other groups
2. If bound to a directory and cannot connect to the directory, `id` doesn't know how to translate the numeric group to a human readable name and errors.
3. The inclusion of all the other users' Public Folders is frivolous, filtered them out

This has not been tested on a wide swath of systems so more testing is requested. I did confirm with @kevinmcox on Slack that it did not cause undo harm to the fixes put in place in https://github.com/munkireport/users/commit/df8a425df5c0748fac76b2e1fd70bcb87859c39b